### PR TITLE
`respond_to? :split` is true for Redis::Namespace instance

### DIFF
--- a/lib/related.rb
+++ b/lib/related.rb
@@ -25,7 +25,7 @@ module Related
   #   5. An instance of `Redis`, `Redis::Client`, `Redis::Distributed`,
   #      or `Redis::Namespace`.
   def redis=(server)
-    if server.respond_to? :split
+    if server.is_a? String
       if server =~ /redis\:\/\//
         redis = Redis.connect(:url => server)
       else


### PR DESCRIPTION
https://github.com/sutajio/related/blob/master/lib/related.rb#L28

This test actually _passes_ when a Redis::Namespace object is passed... which is very strange, but is apparently expected Redis::Namespace behavior to retain interop with Redis for use within Resque.

See https://github.com/resque/redis-namespace/pull/18

Should probably simply check if this is a string, not just responds to a specific method. Any reason this was not the default test?