### PR TITLE
Resolve `uninitialized constant ActiveModel::Serializers::Xml`

### DIFF
--- a/lib/related.rb
+++ b/lib/related.rb
@@ -1,6 +1,7 @@
 require 'redis'
 require 'redis/namespace'
 require 'active_model'
+require 'activemodel-serializers-xml'
 
 require 'related/version'
 require 'related/helpers'

--- a/related.gemspec
+++ b/related.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency('redis',  '> 2.0.0')
   s.add_dependency('redis-namespace',  '> 0.8.0')
   s.add_dependency('activemodel')
+  s.add_dependency('activemodel-serializers-xml')
 end


### PR DESCRIPTION
This fixes a `NameError` that prevents `related` from being loaded.